### PR TITLE
fix: 배포되는 브랜치 main으로 고정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: 
       - "main" # main 브랜치에 푸시하면 실행
-      - "feat/#7"
       
 
 jobs:


### PR DESCRIPTION
## 📌 관련 이슈
- #7 

## ✨ 작업 내용
- 배포 브런치 main으로 고정